### PR TITLE
Changed all appearances of newline to sprintf equivalent. Code appear…

### DIFF
--- a/epsclean.m
+++ b/epsclean.m
@@ -153,11 +153,11 @@ while ~feof(fid1)
             currentBlockContent = {};
         elseif ~isempty(regexp(line, '^GS$', 'once'))
             nested = nested + 1;
-            currentBlockPrefix = [currentBlockPrefix line newline]; %#ok<AGROW>
+            currentBlockPrefix = [currentBlockPrefix line sprintf('\n')]; %#ok<AGROW>
         elseif ~isempty(regexp(line, '^GR$', 'once'))
             if nested > 0
                 nested = nested - 1;
-                currentBlockPrefix = [currentBlockPrefix line newline]; %#ok<AGROW>
+                currentBlockPrefix = [currentBlockPrefix line sprintf('\n')]; %#ok<AGROW>
             else
                 % end of block without a 'N' = newpath command
                 % we don't know what it is, but we take it as a whole
@@ -166,7 +166,7 @@ while ~feof(fid1)
                 operation = 3;
             end
         else
-            currentBlockPrefix = [currentBlockPrefix line newline]; %#ok<AGROW>
+            currentBlockPrefix = [currentBlockPrefix line sprintf('\n')]; %#ok<AGROW>
         end
     elseif operation == 2 % analyze block content
         if ~isempty(regexp(line, 're$', 'once'))


### PR DESCRIPTION
I changed each appearance of "newline" to sprintf('\n') in hopes that this makes the code more compatible. sprintf('\n') should resolve to the correct char strings on windows/mac/linux, I believe. I ran the code and it runs without errors. It appeared to fix some of the triangle path issues I am having with MATLAB's EPS export -- it converted many of the triangle pairs into squares -- but it didn't completely solve my problem. Since I can't run the code as-is, I can't determine if the technique used in the code doesn't work on my EPS, or if my workaround for "newline" breaks the code in some way.